### PR TITLE
Amd xilinx demo documentation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lopper"]
 	path = lopper
 	url = https://github.com/devicetree-org/lopper.git
+[submodule "openamp-system-reference"]
+	path = openamp-system-reference
+	url = https://github.com/OpenAMP/openamp-system-reference.git

--- a/demos/index.rst
+++ b/demos/index.rst
@@ -13,10 +13,13 @@ Samples and Demos
    system_reference-AMD-Xilinx
    system_reference-ST
    ../open-amp/apps/examples/linux_rpc_demo/README
+   docker_images
+   ../hypervisorless_virtio_zcu102/README_demo
+   ../lopper/demos/openamp/README.md
+
+.. toctree::
+   :hidden:
    ../open-amp/apps/machine/microblaze_generic/README
    ../open-amp/docs/apps/echo_test/README
    ../open-amp/docs/apps/matrix_multiply/README
    ../open-amp/docs/apps/rpc_demo/README
-   docker_images
-   ../hypervisorless_virtio_zcu102/README_demo
-   ../lopper/demos/openamp/README.md

--- a/demos/system_reference-AMD-Xilinx.rst
+++ b/demos/system_reference-AMD-Xilinx.rst
@@ -1,10 +1,12 @@
 .. _demos-AMD--work-label:
 
-==================================================
-System Reference Samples and Demos on AMD platform
-==================================================
+=============================================================
+System Reference Samples and Demos on the AMD-Xilinx platform
+=============================================================
 
-Xilinx Echo Test Example
-~~~~~~~~~~~~~~~~~~~~~~~~
+.. toctree::
+   :maxdepth: 2
 
-`WIP document <https://drive.google.com/drive/u/0/folders/1CqerKYLfwtQu0cnDFa00wqwznCpBK5WO>`_ (Note Google doc access is currently restricted to working group members. To publish once it is sufficiently ready)
+   ../openamp-system-reference/examples/linux/rpmsg-echo-test/README.md
+   ../openamp-system-reference/examples/linux/rpmsg-mat-mul/README.md
+   ../openamp-system-reference/examples/linux/rpmsg-proxy-app/README.md


### PR DESCRIPTION
- Add link to openamp-system-reference repo
- pull in content of AMD-xilinx demos documentation from openamp-system-reference repo
