### PR TITLE
fixup! demos: ST: update meta-st repository source

### DIFF
--- a/demos/system_reference-ST.rst
+++ b/demos/system_reference-ST.rst
@@ -56,12 +56,12 @@ From the stm32mp15-demo directory
    git checkout -b WORKING  origin/2.0
    cd -
 
-   git clone https://github.com/STMicroelectronics/meta-st-stm32mp-oss.git layers/meta-openembedded
+   git clone https://github.com/openembedded/meta-openembedded.git layers/meta-openembedded
    cd layers/meta-openembedded
    git checkout -b WORKING origin/kirkstone
    cd -
 
-   git clone https://github.com/arnopo/meta-st-stm32mp-oss.git layers/meta-st/meta-st-stm32mp-oss
+   git clone https://github.com/STMicroelectronics/meta-st-stm32mp-oss.git layers/meta-st/meta-st-stm32mp-oss
    cd layers/meta-st/meta-st-stm32mp-oss
    git checkout -b WORKING origin/kirkstone
    cd -


### PR DESCRIPTION
The meta-openembedded has been updated instead of the meta-st-stm32mp-oss

Signed-off-by: Nicolas GRANGER [nicolas.granger1@st.com]