### PR TITLE
github: update submodules nightly

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -1,0 +1,39 @@
+name: 'Submodules Sync'
+
+on:
+  # Allows you to run this workflow manually from the Actions tab or through HTTP API
+  workflow_dispatch:
+  # run nightly at 4:10 AM UTC (11:10 PM US eastern, 8:10 PM US western)
+  schedule:
+    - cron:  '10 4 * * *'
+
+jobs:
+  sync:
+    name: 'Submodules Sync'
+    runs-on: ubuntu-latest
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        submodules: true
+
+    # Update references
+    - name: Git Sumbodule Update
+      run: |
+        git pull --recurse-submodules
+        git submodule update --remote --recursive
+
+    - name: Commit update
+      run: |
+        git config --global user.name 'GH actions'
+        git config --global user.email 'bot@noreply.github.com'
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        git commit -am "Auto updated submodule references" && git push || echo "No changes to commit"


### PR DESCRIPTION
This is a github action that will update the submodules when run.
Adds a new commit when needed and not when nothing has changed.

Runs nightly and when triggered via webhook or via webUI.

Anything that makes it to the default branch of each submodule (main for most, master for lopper)
should be in openamp-doc latest.  Any review of the doc changes in the submodules should be reviewed in the PR for the submodule itself; the one that will change main in the submodule.  

Generating reviewable docs in the PRs of submodules is still a TODO item.  I have added an issue for that.

Note: the docs generated from this PR will not be interesting as this PR does not change the docs itself.

You can see this in action here:
https://github.com/wmamills/openamp-docs/commits/main

I let the cron job do the update on my main branch.

and the result here:
https://wmamills-openamp-docs.readthedocs.io/en/main/

I plan to accept this PR on Friday unless there are objections or concerns.
