### PR TITLE
README: Redirect end-users to readthedocs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # openamp_docs
-OpenAMP Documentation for Sphinx
+OpenAMP Documentation sources for Sphinx
+
+If you are looking for the end-user version of the documentation, you can find [the OpenAMP Readthedocs site here](https://openamp.readthedocs.io/en/latest/index.html "OpenAMP Readthedocs site").
 
 ## online review
 


### PR DESCRIPTION
Just in case an OpenAMP end user stumbled upon this repo while looking for documentation about OpenAMP, help them find their way there.