### PR TITLE
sync-submodules: update checkout action to V3

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         submodules: true


### PR DESCRIPTION
Node.js 12 actions are deprecated. Use the checkout V3 action to use Node.js 16