### PR TITLE
github actions: run submodule sync only once per week

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -3,9 +3,9 @@ name: 'Submodules Sync'
 on:
   # Allows you to run this workflow manually from the Actions tab or through HTTP API
   workflow_dispatch:
-  # run nightly at 4:10 AM UTC (11:10 PM US eastern, 8:10 PM US western)
+  # run on Sunday at 4:10 AM UTC (11:10 PM US eastern, 8:10 PM US western)
   schedule:
-    - cron:  '10 4 * * *'
+    - cron:  '10 4 * * 0'
 
 jobs:
   sync:


### PR DESCRIPTION
There are a lot of submodule updates happening.
To decrease maintenance commits run this job only once a week. This still allows us to keep roughly up to date w/o a ton of extra commits.

If a submodule change is important to publish immediately the github action can be run from the repo's web UI by any repo owner.