### PR TITLE
RTD: Explicitly declare the conf.py file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,7 @@
 version: 2
 formats: all
+sphinx:
+  configuration: ./conf.py
 build:
   os: "ubuntu-22.04"
   tools:


### PR DESCRIPTION
/ReadTheDocs now mandates that the conf.py file be explicitly named.