### PR TITLE
demos: ST: update Yocto version to scarthgap

### DIFF
--- a/demos/system_reference-ST.rst
+++ b/demos/system_reference-ST.rst
@@ -45,7 +45,7 @@ From the stm32mp15-demo directory
 
 .. code-block:: console
 
-   export YOCTO_VER=nanbield
+   export YOCTO_VER=scarthgap
    cd stm32mp1_distrib_oss
    mkdir -p layers/meta-st
 


### PR DESCRIPTION
Move all the layers to scarthgap.
The meta-st-stm32mp-oss builds and installs:
  - TF-A 4.2.0,
  - OP-TEE 4.2.0,
  - U-Boot v2024.04,
  - Linux kernel v6.10-rc4