### PR TITLE
Eliminate oaos oalk oapi

### DIFF
--- a/openamp/glossary.rst
+++ b/openamp/glossary.rst
@@ -11,9 +11,6 @@ Glossary
     GPL, `GNU General Public License <https://en.wikipedia.org/wiki/GNU_General_Public_License>`_
     IPC, `Inter-Processor Communications <https://en.wikipedia.org/wiki/Inter-process_communication>`_
     LCM,  Life-Cycle Management
-    OALK, OpenAMP Linux Kernel
-    OAOS, `OpenAMP Open Source Project <https://github.com/OpenAMP>`_
-    OAPI, OpenAMP Proprietary Implementations
     RPC, :ref:`Remote Procedure Calls (RPC)<overview-proxy-rpc-work-label>`
     RTOS, Real Time Operating System
     RPMsg, `Remote Processor Messaging <https://en.wikipedia.org/wiki/RPMsg>`_

--- a/openamp/overview.rst
+++ b/openamp/overview.rst
@@ -202,19 +202,23 @@ Operating Environments
 
 OpenAMP aims to provide components which are portable and aim to be environment agnostic.
 
-The result is that OpenAMP is supported in various operating environments through
-  - an `OpenAMP open source project <https://github.com/OpenAMP>`_  (OAOS),
-  - an OpenAMP Linux Kernel (OALK) project, coming through the regular `remoteproc <https://www.kernel.org/doc/html/latest/staging/remoteproc.html>`_/`RPMsg <https://www.kernel.org/doc/html/latest/staging/rpmsg.html>`_/`Virtio <https://docs.kernel.org/driver-api/virtio/virtio.html>`_ efforts in the kernel.
-  - multiple proprietary implementations (OAPI).
+* The OpenAMP libraries
+    * Implements the OpenAMP wire protocols and OpenAMP API
+    * Is highly portable and works in Zephyr, FreeRTOS, NuttX, bare metal (no OS), and Linux userspace
+* The Linux Kernel
+    * Implements the OpenAMP wire protocols
+* Multiple propriety implementations
+    * Implements the OpenAMP wire protocols and optionally the OpenAMP API
+
 
 The operating environments that OpenAMP supports include:
 
-  - Linux user space - OAOS
-  - Linux kernel - OALK
-  - Multiple RTOS's - OAOS/OAPI including `FreeRTOS <https://freertos.org/>`_, `NuttX <https://nuttx.apache.org/>`_, `Zephyr <https://www.zephyrproject.org/>`_, `VxWorks <https://www.windriver.com/products/vxworks>`_, and more
-  - Bare Metal (No OS) - OAOS
-  - In OS's on top of hypervisors - OAOS/OAPI
-  - Within hypervisors - OAPI
+  - Linux user space
+  - Linux kernel
+  - Multiple RTOS's - including `FreeRTOS <https://freertos.org/>`_, `NuttX <https://nuttx.apache.org/>`_, `Zephyr <https://www.zephyrproject.org/>`_, `VxWorks <https://www.windriver.com/products/vxworks>`_, and more
+  - Bare Metal (No OS)
+  - In OS's on top of hypervisors
+  - Within hypervisors
 
 .. _governance-work-label:
 


### PR DESCRIPTION
Address issue https://github.com/OpenAMP/openamp-docs/issues/51 to
remove uncommon acronyms from Operating Environments section of Overview.

This PR is against main-next which looks to be out of date, so will need to do a rebase before merging once main-next is updated.