### PR TITLE
Fix references in rst to md files

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -140,5 +140,9 @@ html_context = {
     }
 }
 
+# Set automatically generated heading anchors to 4 levels, i.e. h1,h2,h3,h4
+myst_heading_anchors = 4
+autosectionlabel_prefix_document = True
+
 print(f"url_base: {url_base}  version: {version}  is_release: {is_release}  is_pr: {is_pr}")
 print(f"html_context: {html_context}")

--- a/demos/echo.rst
+++ b/demos/echo.rst
@@ -106,7 +106,7 @@ It is a Makefile application and can be built using the
 `Yocto rpmsg-echo-test recipe <https://github.com/OpenAMP/meta-openamp/blob/master/recipes-openamp/rpmsg-examples/rpmsg-echo-test_1.0.bb>`_
 
 An example main control script is given in the
-`echo test readme <https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/linux/rpmsg-echo-test/README.md#run-the-demo>`_
+:ref:`echo test readme<openamp-system-reference/examples/linux/rpmsg-echo-test/README:run the demo>`
 
 *******************************
 Reference Board Implementations

--- a/demos/inter_process.rst
+++ b/demos/inter_process.rst
@@ -17,4 +17,4 @@ the main controller system along with the
 `main controller examples <https://github.com/OpenAMP/openamp-system-reference/tree/main/examples/linux>`_.
 
 To build and execute on a Linux system, refer to the
-`example to compile OpenAMP for communication between Linux processes <https://github.com/OpenAMP/open-amp/blob/main/README.md#example-to-compile-openamp-for-communication-between-linux-processes>`_.
+:ref:`example to compile OpenAMP for communication between Linux processes<open-amp/README:example to compile openamp for communication between linux processes:>`.

--- a/demos/system_reference-NXP.rst
+++ b/demos/system_reference-NXP.rst
@@ -28,9 +28,8 @@ Generate the Zephyr rpmsg multi service example
 Initialize the Zephyr environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Refer to `zephyr example readme
-<https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/zephyr/README.md#initialization>`_
-article.
+Refer to :ref:`zephyr example readme<openamp-system-reference/examples/zephyr/README:initialization>` article.
+
 
 Build the Zephyr image
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/demos/system_reference-ST.rst
+++ b/demos/system_reference-ST.rst
@@ -133,7 +133,7 @@ From the zephy_rpmsg_multi_services directory
    west build -b stm32mp157c_dk2 openamp-system-reference/examples/zephyr/rpmsg_multi_services
 
 For details refer to
-`rpmsg_multi_services readme <https://openamp.readthedocs.io/en/latest/openamp-system-reference/examples/zephyr/rpmsg_multi_services/README.html#building-the-application>`_ article.
+:ref:`rpmsg_multi_services readme<openamp-system-reference/examples/zephyr/rpmsg_multi_services/README:building the application>` article.
 
 
 Install the Zephyr binary on the sdcard
@@ -294,4 +294,4 @@ Run the multi RPMsg services demo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Refer to
-`rpmsg multi service <https://openamp.readthedocs.io/en/latest/openamp-system-reference/examples/zephyr/rpmsg_multi_services/README.html#running-the-sample>`_ article.
+:ref:`rpmsg multi service <openamp-system-reference/examples/zephyr/rpmsg_multi_services/README:running the sample>` article.

--- a/demos/system_reference-ST.rst
+++ b/demos/system_reference-ST.rst
@@ -121,7 +121,7 @@ Initialize the Zephyr environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Refer to
-`zephyr example readme <https://openamp.readthedocs.io/en/latest/openamp-system-reference/examples/zephyr/README.html#initialization>`_ article.
+:ref:`zephyr example readme<openamp-system-reference/examples/zephyr/README:initialization>` article.
 
 Build the Zephyr image
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/tools/lopper.rst
+++ b/tools/lopper.rst
@@ -37,7 +37,7 @@ Lopper is built on top of device tree tools, `Device Tree Compiler (DTC) <https:
 References
 ^^^^^^^^^^
 
-`Lopper Architecture Readme <https://github.com/devicetree-org/lopper/blob/systemdt-linaro-demo/README-architecture.md>`_
+:ref:`Lopper Architecture Readme<lopper/README-architecture:lopper processing flow:>`
 
 `Linaro Connect 2020 - System Device Tree & Lopper Slide Set <https://static.linaro.org/connect/lvc20/presentations/LVC20-314-0.pdf>`_
 


### PR DESCRIPTION
To address https://github.com/OpenAMP/openamp-docs/issues/59 enable automatically generated header anchor in sphinx conf.py file including adding the file as prefix to the anchor to ensure that if there are duplicates between files, the anchor remains unique.
Then modify links in readthedocs which reference souce repository markdown files so the document is dynamically linked rather than using the https link to the github file.

This change does not require any modifications to existing source repository markdown files.

Refer comment in https://github.com/OpenAMP/openamp-docs/issues/59 for more details/explanation.