### PR TITLE
Enhance project and library aims

### DIFF
--- a/openamp/overview.rst
+++ b/openamp/overview.rst
@@ -275,24 +275,25 @@ Read more about the OpenAMP System Components :ref:`here<openamp-components-work
 Operating Environments
 **********************
 
-OpenAMP aims to provide components which are portable and aim to be environment agnostic.
+The OpenAMP project aims to provide components which are portable and environment agnostic.
 
--The result is that OpenAMP is supported in various operating environments through
-  - an `OpenAMP open source project <https://github.com/OpenAMP>`_,
-  - an OpenAMP Linux Kernel project, coming through the regular
-    `remoteproc <https://www.kernel.org/doc/html/latest/staging/remoteproc.html>`_/
-    `RPMsg <https://www.kernel.org/doc/html/latest/staging/rpmsg.html>`_/
-    `Virtio <https://docs.kernel.org/driver-api/virtio/virtio.html>`_ efforts in the kernel.
-  - multiple proprietary implementations.
+This is achieved through the OpenAMP library which:
 
-The operating environments that OpenAMP supports include:
-
-  - Linux user space
-  - Linux kernel
-  - Multiple RTOS's - including `FreeRTOS <https://freertos.org/>`_, `NuttX <https://nuttx.apache.org/>`_, `Zephyr <https://www.zephyrproject.org/>`_, `VxWorks <https://www.windriver.com/products/vxworks>`_, and more
-  - Bare Metal (No OS)
-  - In OS's on top of hypervisors
-  - Within hypervisors
+    - implements the Virtio and RPMsg protocols with associated API
+      (`See OpenAMP repository <https://github.com/OpenAMP>`_)
+    - works on different system thanks to the `libmetal <https://github.com/libmetal>`_
+      adaptation layer:
+        - Bare Metal (No OS)
+        - Multiple RTOS's, including `FreeRTOS <https://freertos.org/>`_,
+          `NuttX <https://nuttx.apache.org/>`_, `Zephyr <https://www.zephyrproject.org/>`_,
+          `VxWorks <https://www.windriver.com/products/vxworks>`_, and more
+        - OS's on top of hypervisors
+        - Within hypervisors
+    - is compatible with different compilers such as gcc, clang, armcc and more
+    - maintains compatibility with the Linux kernel by leveraging the following frameworks:
+      `remoteproc <https://www.kernel.org/doc/html/latest/staging/remoteproc.html>`_,
+      `RPMsg <https://www.kernel.org/doc/html/latest/staging/rpmsg.html>`_ and
+      `Virtio <https://docs.kernel.org/driver-api/virtio/virtio.html>`_ frameworks.
 
 
 .. _governance-work-label:
@@ -304,7 +305,7 @@ OpenAMP Governance and Guidelines
 The OpenAMP Project governance is detailed on the
 `OpenAMP Project Page <https://www.openampproject.org/governance/>`_.
 
-There are a few guiding principles that governs OpenAMP:
+There are a few guiding principles, based on the :ref:`project aims<project-aims>` that govern OpenAMP:
 
     - Provide a clean-room implementation of OpenAMP with business friendly APIs and licensing
         * Allow for compatible proprietary implementations and products


### PR DESCRIPTION
Attempt to address issue https://github.com/OpenAMP/openamp-docs/issues/62
Reword project aims and include links to the openampproject.org page also to tie the two sets of information as the information is related.
Reword operating environment to focus on library, with slightly modified suggestion made by Arnaud in PR https://github.com/OpenAMP/openamp-docs/pull/61
