### PR TITLE
Use shell block for commands in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,19 @@ If you wish to build the documents on the desktop, you can do as follows.
 
 Setup Linux system requirements:
 
-    $ sudo apt update
-    $ sudo apt install cmake doxygen libhugetlbfs-dev libsysfs-dev
-    $ sudo apt install python3-pip git
+```shell
+sudo apt update
+sudo apt install cmake doxygen libhugetlbfs-dev libsysfs-dev
+sudo apt install python3-pip git
+```
 
 Setup the document repository on your machine:
 
-    $ git clone --recurse https://github.com/openAMP/openamp-docs.git
-    $ cd openamp-docs
-    $ git submodule update
+```shell
+git clone --recurse https://github.com/openAMP/openamp-docs.git
+cd openamp-docs
+git submodule update
+```
 
 ### Building using virtual environment
 
@@ -66,29 +70,39 @@ When possible it is recommended to use a
 [Python virtual environment](https://docs.python.org/3/library/venv.html)
 (Python 3.3 and higher, required by Ubuntu 24.04 or higher):
 
-    $ python3 -m venv .venv
-    $ . .venv/bin/activate
+```shell
+python3 -m venv .venv
+. .venv/bin/activate
+```
 
 Install pip modules
 
-    $ python3 -m pip install -r requirements.txt
+```shell
+python3 -m pip install -r requirements.txt
+```
 
 #### Activate the virtual environment for build session
 
 When using a virtual environment activate it before each build session:
 
-    $ cd openamp-docs
-    $ . .venv/bin/activate
+```shell
+cd openamp-docs
+. .venv/bin/activate
+```
 
 ### Build and view the html documents
 
-    $ make html
-    $ xdg-open _build/html/index.html
+```shell
+make html
+xdg-open _build/html/index.html
+```
 
 ### Build and view the pdf
 
-    $ make pdf
-    $ xdg-open _build/pdf/openamppdf.pdf
+```shell
+make pdf
+xdg-open _build/pdf/openamppdf.pdf
+```
 
 Notes:
 * The build process currently produces many warnings


### PR DESCRIPTION
To allow the reader to easily copy the commands, use the shell markdown block.
Some IDEs provide a convenient terminal launch button. e.g Pycharm in their bundled Markdown renderer will execute the commands in the built in terminal.
Visual Studio code also has a plugin for it.
[mark-down-shell-runner](https://marketplace.visualstudio.com/items?itemName=shepherd-dev.markdown-shell-runner)

Addresses issue https://github.com/OpenAMP/openamp-docs/issues/73 for openamp-docs and if this is suitable can make same changes in source code repositories.