### PR TITLE
Locate broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ make pdf
 xdg-open _build/pdf/openamppdf.pdf
 ```
 
+### Link Check
+
+Sphinx provides an extension that checks all external links. This process can take up to
+half an hour, and not all reported failures are accurate - some redirects or security measures
+can cause false positives.
+
+All detected “broken links” are listed in the output, allowing you to manually verify them.
+Most IDEs will also hyperlink terminal output to make this easier.
+
+Before submitting a pull request, ensure that you run this check and verify or correct
+reported broken links.
+
+```shell
+SPHINXOPTS="-b linkcheck" make html
+```
+
 Notes:
 * The build process currently produces many warnings
 * The doxygen content is not included in the pdf

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ SPHINXOPTS="-b linkcheck" make html
 ```
 
 Notes:
-* The build process currently produces many warnings
+* The build process produces some, but limited, warnings, so please ensure to diff between
+  builds and correct any new warnings.
 * The doxygen content is not included in the pdf
 * The doxygen content is not styled like the rest of the html documents
 * The doxygen context does not integrate into the menu structure; use the browser back button

--- a/conf.py
+++ b/conf.py
@@ -52,6 +52,7 @@ release = ''
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+# https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder
 extensions = [
     "sphinxcontrib.jquery",
     'sphinx.ext.autosectionlabel',
@@ -62,7 +63,8 @@ extensions = [
     'rst2pdf.pdfbuilder',
     'myst_parser',
     'sphinxcontrib.doxylink',
-    'breathe'
+    'breathe',
+    'sphinx.builders.linkcheck'
 ]
 
 # Name doxylink "links" to library repositories <library>_doc_link as it is a

--- a/demos/docker_images.rst
+++ b/demos/docker_images.rst
@@ -68,7 +68,7 @@ However if you can pull the docker image you should be able to run the demos
 as they are self contained.  Some of the other activities described like
 installing new packages etc may not work without additional effort.
 If needed, please checkout
-`this tutorial <https://www.serverlab.ca/tutorials/containers/docker/how-to-set-the-proxy-for-docker-on-ubuntu/>`_.
+`Use a proxy server with the Docker CLI <https://docs.docker.com/engine/cli/proxy/>`_.
 
 Docker for other host systems
 -----------------------------

--- a/demos/echo.rst
+++ b/demos/echo.rst
@@ -87,7 +87,7 @@ RPMsg Echo Baremetal Source
 ===========================
 
 The RPMsg Echo service application is available as a baremetal solution in the
-`open-amp Repository <https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/legacy_apps/examples/echo/rpmsg-echo.c>`_
+`openamp-system-reference Repository <https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/legacy_apps/examples/echo/rpmsg-echo.c>`_
 
 It is a CMake application and can be built for any remote as long as the relevant
 :ref:`OS/HW abstraction layer<porting-guide-work-label>` components like libmetal are ported for

--- a/demos/inter_process.rst
+++ b/demos/inter_process.rst
@@ -12,8 +12,8 @@ This can be useful for demonstration purposes, but can also be leveraged for com
 as part of a continuous integration setup.
 
 Effectively the `OpenAMP Library <https://github.com/OpenAMP/open-amp/tree/main/lib>`_ and
-`reference examples <https://github.com/OpenAMP/open-amp/tree/main/apps/examples>`_ are built for
-the main controller system along with the
+`reference examples <https://github.com/OpenAMP/openamp-system-reference/tree/main/examples/legacy_apps/examples>`_
+are built for the main controller system along with the
 `main controller examples <https://github.com/OpenAMP/openamp-system-reference/tree/main/examples/linux>`_.
 
 To build and execute on a Linux system, refer to the

--- a/demos/reference_boards.rst
+++ b/demos/reference_boards.rst
@@ -6,8 +6,6 @@ OpenAMP Reference Boards
 virtual machines to demonstrate the implementation of each.
 
 In general the OpenAMP feature being exemplified is found in the
-`OpenAMP source repository <https://github.com/OpenAMP/open-amp/tree/main/apps/examples>`_ through a
-number of examples. Additional supporting code is located in the
 `OpenAMP System Reference examples <https://github.com/OpenAMP/openamp-system-reference/tree/main/examples>`_
 
 .. toctree::

--- a/demos/replicate_firmware.rst
+++ b/demos/replicate_firmware.rst
@@ -63,8 +63,8 @@ Replicate Firmware Main Configuration
 
 The remoteproc configuration binding
 `cluster-mode <https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/remoteproc/xlnx%2Czynqmp-r5fss.yaml#L37>`_
-is set to 0 for split-mode as per the
-`system reference implementation <https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/linux/dts/xilinx/zynqmp-split.dtso>`_.
+is set to disabled for rproc_split.status as per the
+`system reference implementation <https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/linux/dts/xilinx/zynqmp-lockstep.dtso>`_.
 
 ********************************************
 Replicate Firmware Remote Application Source

--- a/demos/system_reference-AMD-Xilinx.rst
+++ b/demos/system_reference-AMD-Xilinx.rst
@@ -6,7 +6,7 @@ System Reference Samples and Demos on the AMD-Xilinx platform
 
 The following Reference Samples and Demos are implemented using the
 
-* AMD `ZCU102 Evaluation Board <https://www.xilinx.com/products/boards-and-kits/ek-u1-zcu102-g.html#information>`_
+* AMD `ZCU102 Evaluation Board <https://www.amd.com/en/products/adaptive-socs-and-fpgas/evaluation-boards/ek-u1-zcu102-g.html>`_
 * `QEMU <https://www.qemu.org/>`_ ZCU102 Virtual Machine in the :ref:`Docker Images References<docker-images-label>`
 
 .. toctree::

--- a/docs/porting_guide.rst
+++ b/docs/porting_guide.rst
@@ -213,11 +213,11 @@ Platform Specific Porting to Use RPMsg
 
 RPMsg in OpenAMP implementation uses `VirtIO <https://docs.oasis-open.org/virtio/virtio/>`_
 to manage the shared buffers. OpenAMP library provides
-`remoteproc VirtIO backend implementation <https://github.com/OpenAMP/open-amp/blob/master/lib/remoteproc/remoteproc_virtio.c>`_.
+`remoteproc VirtIO backend implementation <https://github.com/OpenAMP/open-amp/blob/main/lib/remoteproc/remoteproc_virtio.c>`_.
 You don't have to use remoteproc backend. You can implement your VirtIO backend with the VirtIO
 and RPMsg implementation in OpenAMP. If you want to implement your own VirtIO backend, you can
 refer to the
-`remoteproc VirtIO backend implementation <https://github.com/OpenAMP/open-amp/blob/master/lib/remoteproc/remoteproc_virtio.c>`_.
+`remoteproc VirtIO backend implementation < https://github.com/OpenAMP/open-amp/blob/main/lib/remoteproc/remoteproc_virtio.c>`_.
 
 Here are the steps to use OpenAMP for RPMsg communication:
 

--- a/openamp/overview.rst
+++ b/openamp/overview.rst
@@ -281,13 +281,13 @@ This is achieved through the OpenAMP library which:
 
     - implements the Virtio and RPMsg protocols with associated API
       (`See OpenAMP repository <https://github.com/OpenAMP>`_)
-    - works on different system thanks to the `libmetal <https://github.com/libmetal>`_
+    - works on different system thanks to the `libmetal <https://github.com/OpenAMP/libmetal>`_
       adaptation layer:
 
         - Bare Metal (No OS)
         - Multiple RTOS's, including `FreeRTOS <https://freertos.org/>`_,
           `NuttX <https://nuttx.apache.org/>`_, `Zephyr <https://www.zephyrproject.org/>`_,
-          `VxWorks <https://www.windriver.com/products/vxworks>`_, and more
+          `VxWorks < https://www.windriver.com/products/embedded/vxworks>`_, and more
 
         - OS's on top of hypervisors
         - Within hypervisors

--- a/protocol_details/lifecyclemgmt_creation.rst
+++ b/protocol_details/lifecyclemgmt_creation.rst
@@ -24,7 +24,7 @@ Resource Table Procedure
 
   As an example, please refer to the resource table defined in the bare metal remote echo test
   application at
-  `rsc_table.c <https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/legacy_apps/machine/zynqmp_r5/rsc_table.c>`_.
+  `rsc_table.c <https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.c>`_.
   The resource table contains entries for memory carve-out and virtio device resources. The memory
   carve-out entry contains info like firmware ELF image start address and size. The virtio device
   resource contains virtio device features, vring addresses, size, and alignment information. The

--- a/protocol_details/lifecyclemgmt_overview.rst
+++ b/protocol_details/lifecyclemgmt_overview.rst
@@ -75,4 +75,4 @@ The OpenAMP samples and demos exemplify the use of an application specific messa
 graceful shutdown before the hard remoteproc_shutdown is performed. For an example, see the Shutdown
 Packet in the `Echo Test Messaging Flow diagram<echo-test-control-flow>` which is implemented as the
 SHUTDOWN_MSG in the source
-`open-amp Repository <https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/legacy_apps/examples/echo/rpmsg-echo.c>`_.
+`openamp-system-reference Repository <https://github.com/OpenAMP/openamp-system-reference/blob/main/examples/legacy_apps/examples/echo/rpmsg-echo.c>`_.


### PR DESCRIPTION
This PR adds linkcheck extension to enable location of broken links post build.

Also fix the links in openamp-docs that were found broken.
    
The sphinx linkcheck builder is intended to find broken links.
Not all failures are actual failures as some redirects or security checks break these automated checks. However as all broken links are listed on the output, the person running this can manually verify the link to confirm.
The builder is added to the extensions but as the check takes up to half an hour due to rate limiting of some sites, recommendation is only to run on demand, say before a release, as follows.
    
SPHINXOPTS="-b linkcheck" make html