### PR TITLE
Updates to the ReadtheDocs integration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,9 +27,9 @@ formats: all
 sphinx:
   configuration: ./conf.py
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-26.04"
   tools:
-    python: "3.10"
+    python: "3.14"
   apt_packages:
     - cmake
     - libhugetlbfs-dev

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,27 @@
+# We now do all check-out related operations in the "git checkout command" of
+# the ReadtheDocs project settings.  There is no longer any post_checkout job
+# here.
+#
+# For the main project, the settings should look like:
+#   git clone $READTHEDOCS_GIT_CLONE_URL .
+#   git checkout --force $READTHEDOCS_GIT_IDENTIFIER
+#   git submodule sync
+#   git submodule update --init --force --recursive
+
+# To build PRs for submodules you will need to create a new RTDs project for
+# the submodule repo and enable the "build PRs" setting.
+# Assume:
+#  using the main repo for the openamp-docs project,
+#     you could also use your own fork of openamp-docs if you have one
+#  the submodule is open-amp, fix the "cd" for others
+# The "git checkout command" should look like:
+#   git clone --recurse-submodules https://github.com/OpenAMP/openamp-docs.git .
+#   (cd open-amp; git remote add this_pr $READTHEDOCS_GIT_CLONE_URL )
+#   (cd open-amp; if [ x"$READTHEDOCS_VERSION_TYPE" = x"branch" ]; then git fetch this_pr $READTHEDOCS_GIT_IDENTIFIER; else git fetch this_pr pull/$READTHEDOCS_GIT_IDENTIFIER/head; fi )
+#   (cd open-amp; git checkout --force FETCH_HEAD )
+#   (cd open-amp; git log -n 1 --oneline)
+#   git submodule status
+
 version: 2
 formats: all
 sphinx:
@@ -11,9 +35,6 @@ build:
     - libhugetlbfs-dev
     - libsysfs-dev
   jobs:
-    post_checkout:
-      - git submodule sync
-      - git submodule update --init --force --recursive
     post_install:
       - python -m pip install --exists-action=w --no-cache-dir -r requirements.txt
     pre_build:


### PR DESCRIPTION
This PR contains two commits:
* New process for RTDs projects using the new "git checkout command".  This commit and the described RTDs project setting updates fix the sub-module PR build process and well as make it simpler.
* Update to Ubuntu 26.04 and Python 3.14 (to keep things current)

As of April or May 2026, ReadtheDocs has changed something in their infrastructure that broken the way were doing sub-module PRs.  Luckily, they have added a way to customize the git checkout command used by each RTDs project.  This first commit changes things so we rely on that new setting.

The sub-module checkout procedure is still overly complex as RTDs currently lacks an ENV var that easily describes how to checkout the commit needed for each build.  However the project settings needed are documented in comments in the .readthedocs.yaml file.

This has been tested (with Bill's repo forks) with latest open-amp lib and openamp-docs as of 2026-05-20 2PM UTC.  The open-amp sub-module was tested for pushes to main and for a PR.

NOTE: The RTDs build checks for this PR will fail until I update the RTDs project for the main openamp-docs.  I will do this after I get consenses on the patch.
