### PR TITLE
ReadTheDocs: update the comments to match new git command setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,10 @@
 # here.
 #
 # For the main project, the settings should look like:
+#   env | grep READTHEDOCS
 #   git clone $READTHEDOCS_GIT_CLONE_URL .
-#   git checkout --force $READTHEDOCS_GIT_IDENTIFIER
+#   if [ x"$READTHEDOCS_VERSION_TYPE" = x"branch" ]; then git fetch origin $READTHEDOCS_GIT_IDENTIFIER; else git fetch origin pull/$READTHEDOCS_GIT_IDENTIFIER/head; fi
+#   git checkout --force FETCH_HEAD
 #   git submodule sync
 #   git submodule update --init --force --recursive
 


### PR DESCRIPTION
* In the main repo, when building a PR, we need to fetch the PR.
* Do so even if building a branch so we can use FETCH_HEAD in the git checkout command
* Also print the state of the READTHEDOCS env vars so we can see when things change.

The fetch and checkout logic of the main repo now matches the sub-projects.