### PR TITLE
Add sphinx_copybutton to provide copy button for code blocks on readthedocs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -64,7 +64,8 @@ extensions = [
     'myst_parser',
     'sphinxcontrib.doxylink',
     'breathe',
-    'sphinx.builders.linkcheck'
+    'sphinx.builders.linkcheck',
+    'sphinx_copybutton'
 ]
 
 # Name doxylink "links" to library repositories <library>_doc_link as it is a

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ myst_parser
 sphinxcontrib.jquery
 sphinxcontrib-doxylink
 breathe
+sphinx_copybutton


### PR DESCRIPTION
sphinx does not by default provide a code block copy button as does github and many IDEs, but this can be enabled by including the sphinx_copybutton extension.
This PR adds the extension to the conf file and the requirements.txt file to ensure it is installed before build.

This change was added as part of modifying code blocks to use shell block
https://github.com/OpenAMP/open-amp/pull/697
https://github.com/OpenAMP/libmetal/pull/369
https://github.com/OpenAMP/openamp-system-reference/pull/118
so makes most sense to merge after those are fixed, but technically can be merged independently. If merged independently it would just mean when someone used the copy button it
will copy the leading prompt ($) as well until the other git submodules are merged.

For an example, hover over one of the code blocks on this page
https://openamp--96.org.readthedocs.build/en/96/openamp-system-reference/examples/legacy_apps/examples/echo/README.html
and notice the copy button appear on top right of block.